### PR TITLE
[BUGFIX] Avoid turning ANSI colors off

### DIFF
--- a/colors.sh
+++ b/colors.sh
@@ -5,7 +5,7 @@
 # Fail on all errors
 set -euo pipefail
 
-export NO_COLOR='\033[0m'
+export COLOR_OFF='\033[0m'
 
 export BLACK='\033[0;30m'
 export RED='\033[0;31m'

--- a/output.sh
+++ b/output.sh
@@ -13,15 +13,15 @@ function linefeed {
 
 # Outputs the provided string as a success status message.
 function success {
-  echo -e "${GREEN}$1${NO_COLOR}"
+  echo -e "${GREEN}$1${COLOR_OFF}"
 }
 
 # Outputs the provided string as an error status message.
 function error {
-  echo -e "${RED}$1${NO_COLOR}"
+  echo -e "${RED}$1${COLOR_OFF}"
 }
 
 # Outputs the provided string as a notice status message.
 function notice {
-  echo -e "${YELLOW}$1${NO_COLOR}"
+  echo -e "${YELLOW}$1${COLOR_OFF}"
 }


### PR DESCRIPTION
The environment variable `NO_COLOR` has a predefined meaning.

Also, the official terms for going back to the default color is "color off", not "no color".