### PR TITLE
[BUGFIX] Add a safeguard to the identity question

### DIFF
--- a/setup-personal
+++ b/setup-personal
@@ -5,7 +5,7 @@
 source 'output.sh'
 
 echo 'Setting up personal settings for Oliver Klee …'
-read -p 'Are you Oliver Klee? [y/N] ' identity
+read -r -p 'Are you Oliver Klee? [y/N] ' identity
 if [ "${identity}" != 'y' ]; then
   notice 'Okay then. Exiting.'
   exit 0


### PR DESCRIPTION
This fixes a shellcheck warning.