### PR TITLE
[TASK] Drop installing `deborphan`

### DIFF
--- a/setup-base-system
+++ b/setup-base-system
@@ -14,7 +14,6 @@ sudo apt-get install -y --no-install-recommends --no-install-suggests \
   ausweisapp2 \
   bash-completion \
   curl \
-  deborphan \
   djvulibre-bin \
   etckeeper \
   fonts-roboto \


### PR DESCRIPTION
This package is no longer available with Ubuntu 24.10.

Fixes #86