### PR TITLE
[TASK] Replace `docker-compose` by `docker-compose-plugin`

### DIFF
--- a/setup-containers
+++ b/setup-containers
@@ -30,7 +30,6 @@ else
     docker-buildx-plugin \
     docker-ce \
     docker-ce-cli \
-    docker-compose \
     docker-compose-plugin
 
   echo 'Fixing permissions …'


### PR DESCRIPTION
`docker-compose` is deprecated and not installable due to dependency issues.

Fixes #75