### PR TITLE
[TASK] Install Zoom as `.deb` instead of via Snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !/fstrim-all
 !/git-tools.sh
 !/install-latest-slack.sh
+!/install-latest-zoom.sh
 !/main
 !/memflush
 !/output.sh

--- a/install-latest-zoom.sh
+++ b/install-latest-zoom.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#
+# Unconditionally installs the latest version of Zoom (independent of whether it is already installed or not).
+#
+
+ZOOM_PATH='/tmp/zoom_amd64.deb'
+# The URL is a redirect. So we need to use -L to follow it.
+curl -L 'https://zoom.us/client/latest/zoom_amd64.deb' --output "${ZOOM_PATH}"
+sudo apt install -y "${ZOOM_PATH}"
+rm "${ZOOM_PATH}"
+success 'Done.'

--- a/setup-social
+++ b/setup-social
@@ -25,13 +25,11 @@ fi
 linefeed
 
 echo 'Installing Zoom …'
-PACKAGE_REPORT=$(snap list)
-if echo "${PACKAGE_REPORT}" | grep -q '^zoom-client '; then
+PACKAGE_REPORT=$(dpkg -s zoom)
+if echo "${PACKAGE_REPORT}" | grep -q 'install ok installed'; then
   success 'Already installed.';
 else
-  sudo snap install zoom-client --channel=latest/edge
-  sudo snap connect zoom-client:screencast-legacy
-  success 'Done.'
+  source 'install-latest-zoom.sh'
 fi
 linefeed
 

--- a/update-everything
+++ b/update-everything
@@ -38,6 +38,15 @@ if echo "$PATH_REPORT" | grep -q 'gem'; then
   linefeed
 fi
 
+echo 'Updating Zoom …'
+PACKAGE_REPORT=$(dpkg -s zoom)
+if echo "${PACKAGE_REPORT}" | grep -q 'install ok installed'; then
+  source 'install-latest-zoom.sh'
+else
+  echo 'Not installed.';
+fi
+linefeed
+
 echo 'Updating Composer …'
 COMPOSER_REPORT=$(which composer)
 if echo "${COMPOSER_REPORT}" | grep -q '/composer'; then


### PR DESCRIPTION
The Snap and Flatpak installs are missing part of the UI, and with the current Ubuntu, the dependencies for Zoom are available again.

This reverts commit 8e2bd6568c069d6a6223157e18a59622e38993c1.